### PR TITLE
legg til hemmelig adresse og validering av det

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/Adresse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/Adresse.kt
@@ -4,6 +4,7 @@ data class Adresse(
     val bruksenhetsnummer: String?,
     val adresselinje1: String?,
     val adresselinje2: String?,
-    val postnummer: String,
-    val poststed: String,
+    val postnummer: String?,
+    val poststed: String?,
+    val hemmeligAdresse: Boolean = false,
 )

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/dto/AddressRequestDto.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/dto/AddressRequestDto.kt
@@ -1,7 +1,7 @@
 package no.nav.familie.ks.barnehagelister.rest.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import no.nav.familie.ks.barnehagelister.domene.Adresse
@@ -31,22 +31,60 @@ data class AddressRequestDto(
         description = "Norwegian zip code, four digits",
         example = "0102",
     )
-    @field:NotBlank
     @field:Size(min = 4, max = 4, message = "Zip code must have 4 digits")
     @field:Pattern(regexp = "^[0-9]+(\\.[0-9]+)?$", message = "Zip code must be a numeric field")
-    val zipCode: String,
+    val zipCode: String?,
     @Schema(
         description = "Norwegian city name",
     )
-    @field:NotBlank
-    val postalTown: String,
-)
+    val postalTown: String?,
+    @Schema(
+        description = "Whether the address is confidential or not. No other fields may be set if true",
+        example = "false",
+    )
+    val confidentialAddress: Boolean = false,
+) {
+    @AssertTrue(message = "A confidential address may not have any address fields set")
+    private fun isAddressOrConfidentialAddress(): Boolean =
+        if (confidentialAddress) {
+            noAdressFieldsAreSet()
+        } else {
+            true
+        }
+
+    @AssertTrue(message = "Mandatory fields zipCode and/or postalTown are not set")
+    private fun isMandatoryFieldsSet(): Boolean =
+        if (!confidentialAddress) {
+            !zipCode.isNullOrBlank() && !postalTown.isNullOrBlank()
+        } else {
+            true
+        }
+
+    private fun noAdressFieldsAreSet(): Boolean =
+        unitNumber == null &&
+            addressLine1 == null &&
+            addressLine2 == null &&
+            zipCode == null &&
+            postalTown == null
+}
 
 fun AddressRequestDto.mapTilAdresse(): Adresse =
-    Adresse(
-        bruksenhetsnummer = this.unitNumber,
-        adresselinje1 = this.addressLine1,
-        adresselinje2 = this.addressLine2,
-        postnummer = this.zipCode,
-        poststed = this.postalTown,
-    )
+    if (this.confidentialAddress) {
+        Adresse(
+            null,
+            null,
+            null,
+            null,
+            null,
+            hemmeligAdresse = true,
+        )
+    } else {
+        Adresse(
+            bruksenhetsnummer = this.unitNumber,
+            adresselinje1 = this.addressLine1,
+            adresselinje2 = this.addressLine2,
+            postnummer = this.zipCode,
+            poststed = this.postalTown,
+            hemmeligAdresse = false,
+        )
+    }

--- a/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/BarnehagelisteControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/BarnehagelisteControllerTest.kt
@@ -125,8 +125,14 @@ class BarnehagelisteControllerTest {
         assertThat(problemDetail.errors)
             .hasSize(2)
             .contains(
-                ValideringsfeilInfo("listInformationRequestDto.municipalityNumber", "Municipality number must have 4 digits"),
-                ValideringsfeilInfo("listInformationRequestDto.municipalityNumber", "Municipality number must be a numeric field"),
+                ValideringsfeilInfo(
+                    "listInformationRequestDto.municipalityNumber",
+                    "Municipality number must have 4 digits",
+                ),
+                ValideringsfeilInfo(
+                    "listInformationRequestDto.municipalityNumber",
+                    "Municipality number must be a numeric field",
+                ),
             )
     }
 
@@ -176,10 +182,12 @@ class BarnehagelisteControllerTest {
 
         assertBadRequest(problemDetail)
         assertThat(problemDetail.errors)
-            .hasSize(6)
+            .hasSize(5)
             .contains(
-                ValideringsfeilInfo("kindergartens[0].address.zipCode", "must not be blank"),
-                ValideringsfeilInfo("kindergartens[0].address.postalTown", "must not be blank"),
+                ValideringsfeilInfo(
+                    "kindergartens[0].address.mandatoryFieldsSet",
+                    "Mandatory fields zipCode and/or postalTown are not set",
+                ),
             )
     }
 
@@ -215,7 +223,10 @@ class BarnehagelisteControllerTest {
             .hasSize(5)
             .contains(
                 ValideringsfeilInfo("kindergartens[0].childrenInformation[0].child.lastName", "must not be blank"),
-                ValideringsfeilInfo("kindergartens[0].childrenInformation[0].child.socialSecurityNumber", "must not be blank"),
+                ValideringsfeilInfo(
+                    "kindergartens[0].childrenInformation[0].child.socialSecurityNumber",
+                    "must not be blank",
+                ),
                 ValideringsfeilInfo("kindergartens[0].childrenInformation[0].child.firstName", "must not be blank"),
             )
     }
@@ -268,7 +279,9 @@ class BarnehagelisteControllerTest {
             BarnehagelisteTestdata.gyldigBarnehageliste().copy(
                 kindergartens =
                     listOf(
-                        BarnehagelisteTestdata.lagKindergartenRequestDto().copy(name = "Barnehagenavn", organizationNumber = "03Z1245689"),
+                        BarnehagelisteTestdata
+                            .lagKindergartenRequestDto()
+                            .copy(name = "Barnehagenavn", organizationNumber = "03Z1245689"),
                     ),
             )
 
@@ -280,7 +293,10 @@ class BarnehagelisteControllerTest {
         assertThat(problemDetail.errors)
             .hasSize(2)
             .contains(
-                ValideringsfeilInfo("kindergartens[0].organizationNumber", "Organization number must be a numeric field"),
+                ValideringsfeilInfo(
+                    "kindergartens[0].organizationNumber",
+                    "Organization number must be a numeric field",
+                ),
                 ValideringsfeilInfo("kindergartens[0].organizationNumber", "Organization number must have 9 digits"),
             )
     }
@@ -398,6 +414,51 @@ class BarnehagelisteControllerTest {
             .hasSize(1)
             .contains(
                 ValideringsfeilInfo("listInformationRequestDto.municipalityName", "size must be between 1 and 200"),
+            )
+    }
+
+    @Test
+    fun `POST barnehageliste - valider ingen adresse hvis hemmelig adresse`() {
+        val invalidBarnehageliste =
+            BarnehagelisteTestdata.gyldigBarnehageliste().copy(
+                kindergartens =
+                    listOf(
+                        BarnehagelisteTestdata.lagKindergartenRequestDto().copy(
+                            childrenInformation =
+                                listOf(
+                                    BarnehagelisteTestdata.lagChildInformationRequestDto().copy(
+                                        child =
+                                            PersonRequestDto(
+                                                firstName = "Ola Ola",
+                                                socialSecurityNumber = "02011212345",
+                                                lastName = "Nordmann",
+                                                address =
+                                                    AddressRequestDto(
+                                                        unitNumber = "H0101",
+                                                        addressLine1 = "1",
+                                                        addressLine2 = null,
+                                                        zipCode = "1234",
+                                                        postalTown = "Oslo",
+                                                        confidentialAddress = true,
+                                                    ),
+                                            ),
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
+        val response = sendInvalidBarnehageliste(invalidBarnehageliste)
+
+        val problemDetail = hentProblemDetail(response)
+
+        assertBadRequest(problemDetail)
+        assertThat(problemDetail.errors)
+            .hasSize(1)
+            .contains(
+                ValideringsfeilInfo(
+                    "kindergartens[0].childrenInformation[0].child.address.addressOrConfidentialAddress",
+                    "A confidential address may not have any address fields set",
+                ),
             )
     }
 


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23705)

Legger til hemmelig addresse og validering på at vi enten setter felter som er obligatoriske i addressen (postnummer og poststed) eller setter hemmelig adresse = true.

Valgte å sette hemmelig-adresse-feltet inni Adresse-objektet siden man da alltid behandler adresse som en enhet. Man kan og legge det utenfor, gjerne kom med input hvis du tenker det er lurere.

