### PR TITLE
Vi ønsker å validere at det er samme kommune og leverandør som henter status på innsendte barnehagelister

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/BarnehagelisteService.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/BarnehagelisteService.kt
@@ -16,7 +16,10 @@ class BarnehagelisteService(
 ) {
     private val logger = LoggerFactory.getLogger(BarnehagelisteService::class.java)
 
-    fun mottaBarnehagelister(skjemaV1: SkjemaV1): Barnehagelister {
+    fun mottaBarnehagelister(
+        skjemaV1: SkjemaV1,
+        leverandørOrgNr: String,
+    ): Barnehagelister {
         val eksisterendeBarnehageliste = barnehagelisterRepository.findByIdOrNull(skjemaV1.id)
         if (eksisterendeBarnehageliste != null) {
             logger.info("Barnehagelister med id ${skjemaV1.id} har allerede blitt mottatt tidligere.")
@@ -27,9 +30,10 @@ class BarnehagelisteService(
             barnehagelisterRepository
                 .insert(
                     Barnehagelister(
-                        skjemaV1.id,
-                        skjemaV1,
-                        BarnehagelisteStatus.MOTTATT,
+                        id = skjemaV1.id,
+                        rawJson = skjemaV1,
+                        status = BarnehagelisteStatus.MOTTATT,
+                        leverandorOrgNr = leverandørOrgNr,
                     ),
                 )
 

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/Barnehagelister.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/Barnehagelister.kt
@@ -14,6 +14,7 @@ data class Barnehagelister(
     val status: BarnehagelisteStatus,
     val opprettetTid: LocalDateTime = LocalDateTime.now(),
     val ferdigTid: LocalDateTime? = null,
+    val leverandorOrgNr: String? = null,
 )
 
 fun Barnehagelister.tilKindergartenlistResponse() =

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/ApiExceptionHandler.kt
@@ -111,8 +111,8 @@ class ApiExceptionHandler {
             }
     }
 
-    @ExceptionHandler(value = [UkjentLeverandørFeil::class])
-    fun onUkjentLeverandørFeil(
+    @ExceptionHandler(value = [UgyldigKommuneEllerLeverandørFeil::class])
+    fun onUgyldigKommuneEllerLeverandørFeil(
         e: Exception,
         request: HttpServletRequest,
     ): ProblemDetail =
@@ -128,7 +128,7 @@ class ApiExceptionHandler {
                         "callId" to (MDC.get(MDCConstants.MDC_CALL_ID) ?: IdUtils.generateId()),
                     )
             }.apply {
-                logger.info("Kalte applikasjonen med en ukjent leverandør. ${this.properties}")
-                secureLogger.error("Kalte applikasjonen med en ukjent leverandør. ${this.properties}", e)
+                logger.info("Kalte applikasjonen med en ugyldig kommune eller leverandør. ${this.properties}")
+                secureLogger.error("Kalte applikasjonen med en ugyldig kommune eller leverandør. ${this.properties}", e)
             }
 }

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterController.kt
@@ -30,7 +30,7 @@ class DefaultBarnehagelisterController(
         validerGodkjentLeverandør(request)
         bindingResult.kastValideringsfeilHvisValideringFeiler()
 
-        val leverandørOrgNr = request.hentSupplierId() ?: throw UkjentLeverandørFeil("No supplier in request.")
+        val leverandørOrgNr = request.hentSupplierId() ?: error("No supplier in request.")
 
         val barnehagelister =
             barnehagelisteService.mottaBarnehagelister(formV1RequestDto.mapTilSkjemaV1(), leverandørOrgNr)

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterController.kt
@@ -3,6 +3,7 @@ package no.nav.familie.ks.barnehagelister.rest
 import jakarta.servlet.http.HttpServletRequest
 import no.nav.familie.ks.barnehagelister.domene.BarnehagelisteService
 import no.nav.familie.ks.barnehagelister.domene.tilKindergartenlistResponse
+import no.nav.familie.ks.barnehagelister.interceptor.hentConsumerId
 import no.nav.familie.ks.barnehagelister.interceptor.hentSupplierId
 import no.nav.familie.ks.barnehagelister.rest.dto.FormV1RequestDto
 import no.nav.familie.ks.barnehagelister.rest.dto.KindergartenlistResponse
@@ -29,7 +30,10 @@ class DefaultBarnehagelisterController(
         validerGodkjentLeverandør(request)
         bindingResult.kastValideringsfeilHvisValideringFeiler()
 
-        val barnehagelister = barnehagelisteService.mottaBarnehagelister(formV1RequestDto.mapTilSkjemaV1())
+        val leverandørOrgNr = request.hentSupplierId() ?: throw UkjentLeverandørFeil("No supplier in request.")
+
+        val barnehagelister =
+            barnehagelisteService.mottaBarnehagelister(formV1RequestDto.mapTilSkjemaV1(), leverandørOrgNr)
 
         return barnehagelister.tilKindergartenlistResponse().toResponseEntity()
     }
@@ -40,11 +44,24 @@ class DefaultBarnehagelisterController(
     ): ResponseEntity<KindergartenlistResponse> {
         validerGodkjentLeverandør(request)
 
-        return barnehagelisteService
-            .hentBarnehagelister(id)
-            ?.tilKindergartenlistResponse()
-            ?.toResponseEntity()
-            ?: ResponseEntity.notFound().build()
+        val barnehagelister = barnehagelisteService.hentBarnehagelister(id)
+
+        val leverandørOrgNr = request.hentSupplierId() ?: error("No supplier in request.")
+        val kommunenummer = request.hentConsumerId() ?: error("No municipality in request.")
+
+        return when {
+            barnehagelister != null && barnehagelister.leverandorOrgNr != leverandørOrgNr ->
+                error("The requested kindergarten list were not sent in by supplier $leverandørOrgNr")
+
+            barnehagelister != null && kommunenummer != barnehagelister.rawJson.listeopplysninger.kommunenummer ->
+                error("The requested kindergarten list were not sent in by municipality $kommunenummer")
+
+            else ->
+                barnehagelister
+                    ?.tilKindergartenlistResponse()
+                    ?.toResponseEntity()
+                    ?: ResponseEntity.notFound().build()
+        }
     }
 
     override fun ping(): String = "\"OK\""

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterController.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterController.kt
@@ -51,10 +51,10 @@ class DefaultBarnehagelisterController(
 
         return when {
             barnehagelister != null && barnehagelister.leverandorOrgNr != leverandørOrgNr ->
-                error("The requested kindergarten list were not sent in by supplier $leverandørOrgNr")
+                throw UgyldigKommuneEllerLeverandørFeil("The requested kindergarten list were not sent in by supplier $leverandørOrgNr")
 
             barnehagelister != null && kommunenummer != barnehagelister.rawJson.listeopplysninger.kommunenummer ->
-                error("The requested kindergarten list were not sent in by municipality $kommunenummer")
+                throw UgyldigKommuneEllerLeverandørFeil("The requested kindergarten list were not sent in by municipality $kommunenummer")
 
             else ->
                 barnehagelister
@@ -67,10 +67,10 @@ class DefaultBarnehagelisterController(
     override fun ping(): String = "\"OK\""
 
     private fun validerGodkjentLeverandør(request: HttpServletRequest) {
-        val supplierId = request.hentSupplierId() ?: throw UkjentLeverandørFeil("No supplier in request.")
+        val supplierId = request.hentSupplierId() ?: throw UgyldigKommuneEllerLeverandørFeil("No supplier in request.")
 
         if (supplierId !in godkjenteLeverandører.leverandorer.map { it.orgno }) {
-            throw UkjentLeverandørFeil("Supplier with orgno ${supplierId.substringAfter(":")} is not a known supplier.")
+            throw UgyldigKommuneEllerLeverandørFeil("Supplier with orgno ${supplierId.substringAfter(":")} is not a known supplier.")
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/GodkjenteLeverandører.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/GodkjenteLeverandører.kt
@@ -14,6 +14,6 @@ data class Leverandør(
     var navn: String,
 )
 
-class UkjentLeverandørFeil(
+class UgyldigKommuneEllerLeverandørFeil(
     message: String?,
 ) : Exception(message)

--- a/src/main/resources/db/migration/V4__barnehagelister_legg_til_leverandør_id.sql
+++ b/src/main/resources/db/migration/V4__barnehagelister_legg_til_leverandør_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE barnehagelister
+    ADD COLUMN IF NOT EXISTS leverandor_org_nr VARCHAR default null;

--- a/src/test/kotlin/no/nav/familie/ks/barnehagelister/domene/BarnehagelisteServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/ks/barnehagelister/domene/BarnehagelisteServiceTest.kt
@@ -41,7 +41,7 @@ class BarnehagelisteServiceTest {
             every { mockBarnehagelisterRepository.findByIdOrNull(uuid) } returns lagretBarnehageliste
 
             // Act
-            val barnehageliste = barnehagelisteService.mottaBarnehagelister(eksisterendeSkjemaV1)
+            val barnehageliste = barnehagelisteService.mottaBarnehagelister(eksisterendeSkjemaV1, "testleverandørOrgNr")
 
             // Assert
             verify(exactly = 1) { mockBarnehagelisterRepository.findByIdOrNull(uuid) }
@@ -65,7 +65,7 @@ class BarnehagelisteServiceTest {
             every { mockTaskService.save(any()) } returnsArgument 0
 
             // Act
-            val barnehageliste = barnehagelisteService.mottaBarnehagelister(ikkeEksisterendeSkjemaV1)
+            val barnehageliste = barnehagelisteService.mottaBarnehagelister(ikkeEksisterendeSkjemaV1, "testleverandørOrgNr")
 
             // Assert
             verify(exactly = 1) { mockBarnehagelisterRepository.findByIdOrNull(uuid) }

--- a/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterControllerEnhetTest.kt
+++ b/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterControllerEnhetTest.kt
@@ -1,0 +1,170 @@
+package no.nav.familie.ks.barnehagelister.rest
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import jakarta.servlet.http.HttpServletRequest
+import no.nav.familie.ks.barnehagelister.domene.BarnehagelisteService
+import no.nav.familie.ks.barnehagelister.domene.Barnehagelister
+import no.nav.familie.ks.barnehagelister.interceptor.hentConsumerId
+import no.nav.familie.ks.barnehagelister.interceptor.hentSupplierId
+import no.nav.familie.ks.barnehagelister.rest.dto.BarnehagelisteStatus
+import no.nav.familie.ks.barnehagelister.testdata.SkjemaV1TestData
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+class DefaultBarnehagelisterControllerEnhetTest {
+    private val mockBarnehagelisteService = mockk<BarnehagelisteService>()
+    private val mockGodkjenteLeverandør = mockk<GodkjenteLeverandører>()
+
+    private val barnehagelisterController =
+        DefaultBarnehagelisterController(mockBarnehagelisteService, mockGodkjenteLeverandør)
+
+    @Nested
+    inner class StatusTest {
+        @Test
+        fun `Skal returnere response entity not found dersom forespurt liste ikke finnes`() {
+            // Arrange
+            val mocketRequest = mockk<HttpServletRequest>()
+            mockkStatic(HttpServletRequest::hentConsumerId)
+            mockkStatic(HttpServletRequest::hentSupplierId)
+
+            every { mockBarnehagelisteService.hentBarnehagelister(any()) } returns null
+            every { any<HttpServletRequest>().hentConsumerId() } returns "testKommune"
+            every { any<HttpServletRequest>().hentSupplierId() } returns "testLeverandørOrgNr"
+            every { mockGodkjenteLeverandør.leverandorer } returns
+                listOf(
+                    Leverandør("testLeverandørOrgNr", "testLeverandørNavn"),
+                )
+
+            // Act
+            val responseEntity = barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
+
+            // Assert
+            assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+        }
+
+        @Test
+        fun `Skal kaste feil dersom det ikke er en godkjent leverandør som forsøker å hente status`() {
+            // Arrange
+            val mocketRequest = mockk<HttpServletRequest>()
+            mockkStatic(HttpServletRequest::hentConsumerId)
+            mockkStatic(HttpServletRequest::hentSupplierId)
+
+            every { mockBarnehagelisteService.hentBarnehagelister(any()) } returns null
+            every { any<HttpServletRequest>().hentConsumerId() } returns "testKommune"
+            every { any<HttpServletRequest>().hentSupplierId() } returns "testLeverandørOrgNr2"
+            every { mockGodkjenteLeverandør.leverandorer } returns
+                listOf(
+                    Leverandør("testLeverandørOrgNr", "testLeverandørNavn"),
+                )
+
+            // Act && Assert
+            val exception =
+                assertThrows<UkjentLeverandørFeil> {
+                    barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
+                }
+
+            assertThat(exception.message).isEqualTo("Supplier with orgno testLeverandørOrgNr2 is not a known supplier.")
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil dersom det ikke er samme leverandør som forsøker å hente status på innsendt barnehagelister`() {
+        // Arrange
+        val mocketRequest = mockk<HttpServletRequest>()
+        mockkStatic(HttpServletRequest::hentConsumerId)
+        mockkStatic(HttpServletRequest::hentSupplierId)
+
+        val lagetBarnehagelister =
+            Barnehagelister(
+                id = UUID.randomUUID(),
+                rawJson = SkjemaV1TestData.lagSkjemaV1(),
+                status = BarnehagelisteStatus.FERDIG,
+                leverandorOrgNr = "testLeverandørOrgNr3",
+            )
+
+        every { mockBarnehagelisteService.hentBarnehagelister(any()) } returns lagetBarnehagelister
+        every { any<HttpServletRequest>().hentConsumerId() } returns "1234"
+        every { any<HttpServletRequest>().hentSupplierId() } returns "testLeverandørOrgNr2"
+        every { mockGodkjenteLeverandør.leverandorer } returns
+            listOf(
+                Leverandør("testLeverandørOrgNr2", "testLeverandørNavn"),
+            )
+
+        // Act && Assert
+        val exception =
+            assertThrows<IllegalStateException> {
+                barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
+            }
+
+        assertThat(exception.message).isEqualTo("The requested kindergarten list were not sent in by supplier testLeverandørOrgNr2")
+    }
+
+    @Test
+    fun `Skal kaste feil dersom det ikke er samme kommune som forsøker å hente status på innsendt barnehagelister`() {
+        // Arrange
+        val mocketRequest = mockk<HttpServletRequest>()
+        mockkStatic(HttpServletRequest::hentConsumerId)
+        mockkStatic(HttpServletRequest::hentSupplierId)
+
+        val lagetBarnehagelister =
+            Barnehagelister(
+                id = UUID.randomUUID(),
+                rawJson = SkjemaV1TestData.lagSkjemaV1(),
+                status = BarnehagelisteStatus.FERDIG,
+                leverandorOrgNr = "testLeverandørOrgNr3",
+            )
+
+        every { mockBarnehagelisteService.hentBarnehagelister(any()) } returns lagetBarnehagelister
+        every { any<HttpServletRequest>().hentConsumerId() } returns "12345"
+        every { any<HttpServletRequest>().hentSupplierId() } returns "testLeverandørOrgNr3"
+        every { mockGodkjenteLeverandør.leverandorer } returns
+            listOf(
+                Leverandør("testLeverandørOrgNr3", "testLeverandørNavn"),
+            )
+
+        // Act & Assert
+        val exception =
+            assertThrows<IllegalStateException> {
+                barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
+            }
+
+        assertThat(exception.message).isEqualTo("The requested kindergarten list were not sent in by municipality 12345")
+    }
+
+    @Test
+    fun `Skal returnere status dersom barnehagelister forsøkes hent av samme kommune og leverandør`() {
+        // Arrange
+        val mocketRequest = mockk<HttpServletRequest>()
+        mockkStatic(HttpServletRequest::hentConsumerId)
+        mockkStatic(HttpServletRequest::hentSupplierId)
+
+        val uuid = UUID.randomUUID()
+        val lagetBarnehagelister =
+            Barnehagelister(
+                id = uuid,
+                rawJson = SkjemaV1TestData.lagSkjemaV1(),
+                status = BarnehagelisteStatus.FERDIG,
+                leverandorOrgNr = "testLeverandørOrgNr3",
+            )
+
+        every { mockBarnehagelisteService.hentBarnehagelister(any()) } returns lagetBarnehagelister
+        every { any<HttpServletRequest>().hentConsumerId() } returns "1234"
+        every { any<HttpServletRequest>().hentSupplierId() } returns "testLeverandørOrgNr3"
+        every { mockGodkjenteLeverandør.leverandorer } returns
+            listOf(
+                Leverandør("testLeverandørOrgNr3", "testLeverandørNavn"),
+            )
+
+        // Act
+        val responseEntity = barnehagelisterController.status(uuid, mocketRequest)
+
+        // Assert
+        assertThat(responseEntity.body?.status).isEqualTo(BarnehagelisteStatus.MOTTATT.engelsk)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterControllerEnhetTest.kt
+++ b/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/DefaultBarnehagelisterControllerEnhetTest.kt
@@ -65,7 +65,7 @@ class DefaultBarnehagelisterControllerEnhetTest {
 
             // Act && Assert
             val exception =
-                assertThrows<UkjentLeverandørFeil> {
+                assertThrows<UgyldigKommuneEllerLeverandørFeil> {
                     barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
                 }
 
@@ -98,7 +98,7 @@ class DefaultBarnehagelisterControllerEnhetTest {
 
         // Act && Assert
         val exception =
-            assertThrows<IllegalStateException> {
+            assertThrows<UgyldigKommuneEllerLeverandørFeil> {
                 barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
             }
 
@@ -130,7 +130,7 @@ class DefaultBarnehagelisterControllerEnhetTest {
 
         // Act & Assert
         val exception =
-            assertThrows<IllegalStateException> {
+            assertThrows<UgyldigKommuneEllerLeverandørFeil> {
                 barnehagelisterController.status(UUID.randomUUID(), mocketRequest)
             }
 

--- a/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/UnprotectedBarnehagelisteController.kt
+++ b/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/UnprotectedBarnehagelisteController.kt
@@ -29,7 +29,10 @@ class UnprotectedBarnehagelisteController(
         bindingResult.kastValideringsfeilHvisValideringFeiler()
 
         val barnehagelister =
-            barnehagelisteService.mottaBarnehagelister(formV1RequestDto.mapTilSkjemaV1())
+            barnehagelisteService.mottaBarnehagelister(
+                formV1RequestDto.mapTilSkjemaV1(),
+                "testleverandørOrgNr",
+            )
 
         return barnehagelister.tilKindergartenlistResponse().toResponseEntity()
     }

--- a/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/UnprotectedBarnehagelisteControllerIntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/familie/ks/barnehagelister/rest/UnprotectedBarnehagelisteControllerIntegrasjonTest.kt
@@ -34,7 +34,7 @@ import java.nio.charset.Charset
 @ActiveProfiles("dev")
 @ContextConfiguration(initializers = [DbContainerInitializer::class])
 @EnableMockOAuth2Server
-class BarnehagelisteControllerTest {
+class UnprotectedBarnehagelisteControllerIntegrasjonTest {
     @Autowired
     lateinit var mockMvc: MockMvc
 


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23516

Vi ønsker å validere at det er samme kommune og leverandør som henter status på innsendte barnehagelister. 
For å gjøre dette så har jeg:

- Laget ny kolonne i tabellen barnehagelister for å legge til leverandør org nummer. Dette fordi nåværende objekt ikke inneholder data om leverandør som sendte inn lister (men har allerede kommunenummer)
- Kaster feil dersom det ikke er samme kommune / leverandør som henter status på innsendt barnehageliste
- Laget enhetstester på kontrolleren for dette. Dette er fordi at integrasjonstesten vi har på kontroller bare kjører på den ubeskyttede kontrolleren, noe jeg mener er en svakhet per nå.

På sikt bør vi refaktorere pakker, ser at integrasjonstester og vanlige enhetestester er i samme pakke nå.