### PR TITLE
legg til gruppering av dependabot-PRer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
         patterns:
           - "org.springframework*"
           - "no.nav.security*"
+          - "org.springdoc*"
       prod-avhengigheter:
         dependency-type: "production"
         exclude-patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,22 @@ updates:
     open-pull-requests-limit: 10
     registries:
       - github
+    groups:
+      interne-avhengigheter:
+        patterns:
+          - "no.nav.familie*"
+      spring-med-avhengigheter:
+        patterns:
+          - "org.springframework*"
+          - "no.nav.security*"
+      prod-avhengigheter:
+        dependency-type: "production"
+        exclude-patterns:
+          - "no.nav.security*"
+      utvikler-avhengigheter:
+        dependency-type: "development"
+        exclude-patterns:
+          - "no.nav.security*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Legger til gruppering av dependabotPR-er slik at det blir lettere å ha oversikt og å gjøre oppdateringer som hører sammen (f.eks. spring-boot).