### PR TITLE
Flytt warnings ut av links i responsobjekt

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/Barnehageliste.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/domene/Barnehageliste.kt
@@ -6,6 +6,8 @@ import no.nav.familie.ks.barnehagelister.rest.dto.FormV1RequestDto
 import no.nav.familie.ks.barnehagelister.rest.dto.KindergartenlistResponse
 import no.nav.familie.ks.barnehagelister.rest.dto.ResponseLinksResponseDto
 import org.springframework.data.annotation.Id
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
+import java.net.URI
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -31,7 +33,7 @@ fun Barnehageliste.tilKindergartenlistResponse(barnehagelisteValideringsfeil: Li
         finishedTime = ferdigTid,
         links =
             ResponseLinksResponseDto(
-                status = "/api/kindergartenlists/status/$id",
+                status = URI.create("${getBaseUrl()}/api/kindergartenlists/status/$id"),
                 warnings =
                     barnehagelisteValideringsfeil.map {
                         EtterprosesseringfeilInfo(
@@ -41,3 +43,5 @@ fun Barnehageliste.tilKindergartenlistResponse(barnehagelisteValideringsfeil: Li
                     },
             ),
     )
+
+private fun getBaseUrl() = ServletUriComponentsBuilder.fromCurrentContextPath().toUriString()

--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/dto/KindergartenlistResponse.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/rest/dto/KindergartenlistResponse.kt
@@ -2,6 +2,7 @@ package no.nav.familie.ks.barnehagelister.rest.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.http.ResponseEntity
+import java.net.URI
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -10,16 +11,21 @@ data class KindergartenlistResponse(
     val status: BarnehagelisteStatusEngelsk,
     val receivedTime: LocalDateTime,
     val finishedTime: LocalDateTime?,
+    val warnings: List<EtterprosesseringfeilInfo> = emptyList(),
     val links: ResponseLinksResponseDto,
 )
 
 @Schema(description = "A URI reference to endpoint to get the status for the submitted kindergarten list", name = "ResponseLinks")
 data class ResponseLinksResponseDto(
-    val status: String,
-    val warnings: List<EtterprosesseringfeilInfo> = emptyList(),
+    val status: URI,
 )
 
-@Schema(name = "ValidationWarnings")
+@Schema(
+    name = "ValidationWarnings",
+    description =
+        "Validation warnings on inconsistencies within the kindergarten list. " +
+            "Will be empty until status = DONE.",
+)
 data class EtterprosesseringfeilInfo(
     @Schema()
     val type: EtterprosesseringfeilType,


### PR DESCRIPTION
Flytter warnings ut av links i responsobjektet og legger til full uri på statusendepunktet.