### PR TITLE
sjekk overlapp på perioder kun innenfor samme barnehage

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/task/PeriodeOverlappValideringTask.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/task/PeriodeOverlappValideringTask.kt
@@ -43,7 +43,9 @@ class PeriodeOverlappValideringTask(
         val alleValideringsfeil =
             listaGruppertPåBarn.mapNotNull { (barn, listeMedBarnehagebarn) ->
                 try {
-                    listeMedBarnehagebarn.validerIngenOverlapp()
+                    listeMedBarnehagebarn.groupBy { it.organisasjonsnummer }.forEach { _, barnISammeBarnehage ->
+                        barnISammeBarnehage.validerIngenOverlapp()
+                    }
                     null
                 } catch (e: Exception) {
                     logger.info("Overlappende perioder på barnehageliste $barnehagelisteId")


### PR DESCRIPTION
Fikk feil i prod der et barn som har overlappende perioder i forskjellige barnehager ikke går gjennom validering. Valideringen skal egentlig kun slå ut dersom det er innenfor samme barnehage.

Grupperer på orgnr til barnehagen før vi sjekker overlapp. 