### PR TITLE
lenke til bruksvilkår i dokumentasjonen

### DIFF
--- a/src/main/kotlin/no/nav/familie/ks/barnehagelister/config/SwaggerDocumentationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/ks/barnehagelister/config/SwaggerDocumentationConfig.kt
@@ -28,6 +28,9 @@ class SwaggerDocumentationConfig {
 ### Description
 The Familie KS Barnehagelister API is designed to process and receive kindergarten lists relevant to Kontantstøtte. The API provides a structured endpoint for submitting kindergarten lists in compliance with [Forskrift om føring av register til bruk i forbindelse med kontroll av beregning og utbetaling av kontantstøtte](https://lovdata.no/dokument/SF/forskrift/2005-12-16-1510?q=kontantst%C3%B8tte). 
 
+### Terms of use
+Terms of use for the api can be found [here](https://github.com/navikt/familie-ks-barnehagelister/raw/main/v1.1%20Bruksvilk%C3%A5r%20NAVs%20API%20for%20elektronisk%20innsending%20av%20barnehagelister.pdf)
+
 ### Submission frequency   
 Kindergarten lists should be submitted before the 1. of every month. A small period of time is allowed so it is possible to correct the data, the last date for submission for the current month is the 10. of said month. A municipality may have several submissions within the same month to allow for corrections. 
 


### PR DESCRIPTION
Legg til lenke til bruksvilkårene i dokumentasjonen av API-et så det er lett å finne frem til