### PR TITLE
sett default swagger-endepunkt til true så vi slipper warns

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,7 +39,9 @@ management:
 
 springdoc:
   swagger-ui:
-    disable-swagger-default-url: true
+    enabled: true
+  api-docs:
+    enabled: true
 
 prosessering:
   rolle: "87190cf3-b278-457d-8ab7-1a5c55a9edd7" # Gruppen teamfamilie


### PR DESCRIPTION
### 📮 Favro: 

### 💰 Hva skal gjøres, og hvorfor?
Får en del warns på at default-swagger-endepunkt er mulige å nå i prod. Dette er ønskelig siden den inneholder dokumentasjon for eksterne brukere. Setter verdiene til true slik at WARN-meldingene forsvinner.

### 🔎️ Er det noe spesielt du ønsker tilbakemelding om?


### ✅ Checklist
_Har du husket alle punktene i listen?_
- [ ] Jeg har testet mine endringer i henhold til akseptansekriteriene 🕵️
- [ ] Jeg har config- eller sql-endringer.
- [ ] Jeg har skrevet tester.

_Jeg har ikke skrevet tester fordi:_
